### PR TITLE
Rename 'pk' to 'id' to fix syncing error

### DIFF
--- a/addon/lingq.py
+++ b/addon/lingq.py
@@ -54,8 +54,7 @@ def get_all_cards(api_key):
             courses = get_courses(api_key, language)
 
             for course in courses:
-
-                lessons = get_lessons(api_key, language, course["pk"])
+                lessons = get_lessons(api_key, language, course["id"])
                 course['lessons'] = lessons
 
                 threads = []


### PR DESCRIPTION
Implements the fix suggested by @jonathanglasmeyer in #1 

I verified this worked with my Lingq account and Anki on Mac